### PR TITLE
Wda3 226 dll uit core importeren in otap

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5,101 +5,13 @@ on:
       - master
       - staging
       - development
-      
+
 jobs:
   deploy_dev:
     name: DEV
     if: github.ref == 'refs/heads/development'
-    environment: 
-      name: DEV   
-    runs-on: self-hosted
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Prune old images
-      run: docker image prune -a -f
-      working-directory: ${{ github.workspace }}
-
-    - name: Build and start container for Development
-      run: |
-        docker compose build
-        docker compose -f docker-compose.yml -p ${{ vars.ENV_KEY }}-server up -d --remove-orphans
-      env:
-        API_PORT: '${{ vars.API_PORT }}'
-        MVC_PORT: '${{ vars.MVC_PORT }}'
-        ASPNETCORE_ENVIRONMENT: '${{ vars.ASPNETCORE_ENVIRONMENT }}'
-        DB_HOST: '${{ vars.DB_HOST }}'
-        DB_NAME: '${{ vars.DB_NAME }}'
-        DB_USER: '${{ secrets.DB_USER }}'
-        DB_PASSWORD: '${{ secrets.DB_PASSWORD }}'
-        ENV_KEY: '${{ vars.ENV_KEY }}'   
-      working-directory: ${{ github.workspace }}
-
-  deploy_tst:
-    name: TST
-    if: github.ref == 'refs/heads/staging'
-    environment: 
-      name: TST   
-    runs-on: self-hosted
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Prune old images
-      run: docker image prune -a -f
-      working-directory: ${{ github.workspace }}
-
-    - name: Build and start container for Development
-      run: |
-        docker compose build
-        docker compose -f docker-compose.yml -p ${{ vars.ENV_KEY }}-server up -d --remove-orphans
-      env:
-        API_PORT: '${{ vars.API_PORT }}'
-        MVC_PORT: '${{ vars.MVC_PORT }}'
-        ASPNETCORE_ENVIRONMENT: '${{ vars.ASPNETCORE_ENVIRONMENT }}'
-        DB_HOST: '${{ vars.DB_HOST }}'
-        DB_NAME: '${{ vars.DB_NAME }}'
-        DB_USER: '${{ secrets.DB_USER }}'
-        DB_PASSWORD: '${{ secrets.DB_PASSWORD }}'
-        ENV_KEY: '${{ vars.ENV_KEY }}'   
-      working-directory: ${{ github.workspace }}
-
-  deploy_acc:
-    name: ACC
-    if: github.ref == 'refs/heads/staging'
-    environment: 
-      name: ACC   
-    runs-on: self-hosted
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Prune old images
-      run: docker image prune -a -f
-      working-directory: ${{ github.workspace }}
-
-    - name: Build and start container for Development
-      run: |
-        docker compose build
-        docker compose -f docker-compose.yml -p ${{ vars.ENV_KEY }}-server up -d --remove-orphans
-      env:
-        API_PORT: '${{ vars.API_PORT }}'
-        MVC_PORT: '${{ vars.MVC_PORT }}'
-        ASPNETCORE_ENVIRONMENT: '${{ vars.ASPNETCORE_ENVIRONMENT }}'
-        DB_HOST: '${{ vars.DB_HOST }}'
-        DB_NAME: '${{ vars.DB_NAME }}'
-        DB_USER: '${{ secrets.DB_USER }}'
-        DB_PASSWORD: '${{ secrets.DB_PASSWORD }}'
-        ENV_KEY: '${{ vars.ENV_KEY }}'   
-      working-directory: ${{ github.workspace }}
-        
-        
-  deploy_prod:
-    name: PRD
-    if: github.ref == 'refs/heads/master'
-    environment: 
-      name: PRD        
+    environment:
+      name: DEV
     runs-on: self-hosted
     steps:
       - name: Checkout repository
@@ -109,17 +21,144 @@ jobs:
         run: docker image prune -a -f
         working-directory: ${{ github.workspace }}
 
+      - name: Build shared dll
+        run: |
+          export DOTNET_ROOT=$HOME/.dotnet
+          export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+          cd ./KeuzeWijzerCore && dotnet publish --os linux --arch x64 /t:PublishContainer
+
+      - name: Copy shared dll
+        run: |
+          cp ./KeuzeWijzerCore/bin/Release/net8.0/linux-x64/KeuzeWijzerCore.dll ./
+
+      - name: Build and start container for Development
+        run: |
+          docker compose build
+          docker compose -f docker-compose.yml -p ${{ vars.ENV_KEY }}-server up -d --remove-orphans
+        env:
+          API_PORT: "${{ vars.API_PORT }}"
+          MVC_PORT: "${{ vars.MVC_PORT }}"
+          ASPNETCORE_ENVIRONMENT: "${{ vars.ASPNETCORE_ENVIRONMENT }}"
+          DB_HOST: "${{ vars.DB_HOST }}"
+          DB_NAME: "${{ vars.DB_NAME }}"
+          DB_USER: "${{ secrets.DB_USER }}"
+          DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
+          ENV_KEY: "${{ vars.ENV_KEY }}"
+        working-directory: ${{ github.workspace }}
+
+  deploy_tst:
+    name: TST
+    if: github.ref == 'refs/heads/staging'
+    environment:
+      name: TST
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Prune old images
+        run: docker image prune -a -f
+        working-directory: ${{ github.workspace }}
+
+      - name: Build shared dll
+        run: |
+          export DOTNET_ROOT=$HOME/.dotnet
+          export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+          cd ./KeuzeWijzerCore && dotnet publish --os linux --arch x64 /t:PublishContainer
+
+      - name: Copy shared dll
+        run: |
+          cp ./KeuzeWijzerCore/bin/Release/net8.0/linux-x64/KeuzeWijzerCore.dll ./
+
+      - name: Build and start container for Development
+        run: |
+          docker compose build
+          docker compose -f docker-compose.yml -p ${{ vars.ENV_KEY }}-server up -d --remove-orphans
+        env:
+          API_PORT: "${{ vars.API_PORT }}"
+          MVC_PORT: "${{ vars.MVC_PORT }}"
+          ASPNETCORE_ENVIRONMENT: "${{ vars.ASPNETCORE_ENVIRONMENT }}"
+          DB_HOST: "${{ vars.DB_HOST }}"
+          DB_NAME: "${{ vars.DB_NAME }}"
+          DB_USER: "${{ secrets.DB_USER }}"
+          DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
+          ENV_KEY: "${{ vars.ENV_KEY }}"
+        working-directory: ${{ github.workspace }}
+
+  deploy_acc:
+    name: ACC
+    if: github.ref == 'refs/heads/staging'
+    environment:
+      name: ACC
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Prune old images
+        run: docker image prune -a -f
+        working-directory: ${{ github.workspace }}
+
+      - name: Build shared dll
+        run: |
+          export DOTNET_ROOT=$HOME/.dotnet
+          export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+          cd ./KeuzeWijzerCore && dotnet publish --os linux --arch x64 /t:PublishContainer
+
+      - name: Copy shared dll
+        run: |
+          cp ./KeuzeWijzerCore/bin/Release/net8.0/linux-x64/KeuzeWijzerCore.dll ./
+
+      - name: Build and start container for Development
+        run: |
+          docker compose build
+          docker compose -f docker-compose.yml -p ${{ vars.ENV_KEY }}-server up -d --remove-orphans
+        env:
+          API_PORT: "${{ vars.API_PORT }}"
+          MVC_PORT: "${{ vars.MVC_PORT }}"
+          ASPNETCORE_ENVIRONMENT: "${{ vars.ASPNETCORE_ENVIRONMENT }}"
+          DB_HOST: "${{ vars.DB_HOST }}"
+          DB_NAME: "${{ vars.DB_NAME }}"
+          DB_USER: "${{ secrets.DB_USER }}"
+          DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
+          ENV_KEY: "${{ vars.ENV_KEY }}"
+        working-directory: ${{ github.workspace }}
+
+  deploy_prod:
+    name: PRD
+    if: github.ref == 'refs/heads/master'
+    environment:
+      name: PRD
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Prune old images
+        run: docker image prune -a -f
+        working-directory: ${{ github.workspace }}
+
+      - name: Build shared dll
+        run: |
+          export DOTNET_ROOT=$HOME/.dotnet
+          export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+          cd ./KeuzeWijzerCore && dotnet publish --os linux --arch x64 /t:PublishContainer
+
+      - name: Copy shared dll
+        run: |
+          cp ./KeuzeWijzerCore/bin/Release/net8.0/linux-x64/KeuzeWijzerCore.dll ./
+
       - name: Build and start container for Production
         run: |
           docker compose build
           docker compose -f docker-compose.yml -p ${{ vars.ENV_KEY }}-server up -d --remove-orphans
         env:
-         API_PORT: '${{ vars.API_PORT }}'
-         MVC_PORT: '${{ vars.MVC_PORT }}'
-         ASPNETCORE_ENVIRONMENT: '${{ vars.ASPNETCORE_ENVIRONMENT }}'
-         DB_HOST: '${{ vars.DB_HOST }}'
-         DB_NAME: '${{ vars.DB_NAME }}'
-         DB_USER: '${{ secrets.DB_USER }}'
-         DB_PASSWORD: '${{ secrets.DB_PASSWORD }}'
-         ENV_KEY: '${{ vars.ENV_KEY }}'            
-        working-directory: ${{ github.workspace }}
+          API_PORT: "${{ vars.API_PORT }}"
+          MVC_PORT: "${{ vars.MVC_PORT }}"
+          ASPNETCORE_ENVIRONMENT: "${{ vars.ASPNETCORE_ENVIRONMENT }}"
+          DB_HOST: "${{ vars.DB_HOST }}"
+          DB_NAME: "${{ vars.DB_NAME }}"
+          DB_USER: "${{ secrets.DB_USER }}"
+          DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
+          ENV_KEY: "${{ vars.ENV_KEY }}"
+          working-directory: ${{ github.workspace }}

--- a/Api/KeuzeWijzerApi.csproj
+++ b/Api/KeuzeWijzerApi.csproj
@@ -31,10 +31,11 @@
     <Folder Include="Models\" />
     <Folder Include="Services\" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <Reference Include="KeuzeWijzerCore">
-      <HintPath>..\KeuzeWijzerCore\bin\Debug\net8.0\KeuzeWijzerCore.dll</HintPath>
+      <HintPath Condition="Exists('..\KeuzeWijzerCore\bin\Debug\net8.0\KeuzeWijzerCore.dll')">..\KeuzeWijzerCore\bin\Debug\net8.0\KeuzeWijzerCore.dll</HintPath>
+      <HintPath Condition="Exists('/app/KeuzeWijzerCore.dll')">/app/KeuzeWijzerCore.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/DockerfileApi
+++ b/DockerfileApi
@@ -9,14 +9,18 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["KeuzeWijzerApi.csproj", "."]
+COPY ["./KeuzeWijzerCore.dll", "/app/"]
+COPY ["Api/KeuzeWijzerApi.csproj", "."]
 RUN dotnet restore "./KeuzeWijzerApi.csproj"
-COPY . .
+
+COPY ./Api .
 WORKDIR "/src/."
+
 RUN dotnet build "./KeuzeWijzerApi.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
+
 RUN dotnet publish "./KeuzeWijzerApi.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final

--- a/DockerfileMvc
+++ b/DockerfileMvc
@@ -9,14 +9,18 @@ EXPOSE 8083
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["KeuzeWijzerMvc.csproj", "."]
+COPY ["./KeuzeWijzerCore.dll", "/app/"]
+COPY ["Mvc/KeuzeWijzerMvc.csproj", "."]
 RUN dotnet restore "./KeuzeWijzerMvc.csproj"
-COPY . .
+
+COPY ./Mvc .
 WORKDIR "/src/."
+
 RUN dotnet build "./KeuzeWijzerMvc.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
+
 RUN dotnet publish "./KeuzeWijzerMvc.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final

--- a/Mvc/KeuzeWijzerMvc.csproj
+++ b/Mvc/KeuzeWijzerMvc.csproj
@@ -23,7 +23,8 @@
 
   <ItemGroup>
     <Reference Include="KeuzeWijzerCore">
-      <HintPath>..\KeuzeWijzerCore\bin\Debug\net8.0\KeuzeWijzerCore.dll</HintPath>
+      <HintPath Condition="Exists('..\KeuzeWijzerCore\bin\Debug\net8.0\KeuzeWijzerCore.dll')">..\KeuzeWijzerCore\bin\Debug\net8.0\KeuzeWijzerCore.dll</HintPath>
+      <HintPath Condition="Exists('/app/KeuzeWijzerCore.dll')">/app/KeuzeWijzerCore.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ services:
   api:
     image: keuzewijzer-api:${ENV_KEY}
     build:
-      context: ./Api
-      dockerfile: Dockerfile
+      context: ./
+      dockerfile: DockerfileApi
     ports:
       - "${API_PORT}:8080"
+    volumes:
+      - ./KeuzeWijzerCore.dll:/app/KeuzeWijzerCore.dll:r
     environment:
       ASPNETCORE_HTTP_PORTS: "8080"
       ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
@@ -16,12 +18,12 @@ services:
   mvc:
     image: keuzewijzer-mvc:${ENV_KEY}
     build:
-      context: ./Mvc
-      dockerfile: Dockerfile
+      context: ./
+      dockerfile: DockerfileMvc
     ports:
       - "${MVC_PORT}:8082"
     environment:
-      ApiUri__ApiUri: "http://api:8080/"
+      ApiUri__ApiUri: "${ENV_KEY}-server-mvc-1:${API_PORT}"
       ASPNETCORE_HTTP_PORTS: "8082"
       ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT}
       DB_CONNECTION_STRING: "host=${DB_HOST};port=1433;database=${DB_NAME};username=${DB_USER};password=${DB_PASSWORD}"


### PR DESCRIPTION
Deze PR maakt het mogelijk om de DLL te gebruiken uit het shared project in de OTA omgeving. 

De DLL wordt nu in de GitHub action gebuild op de server, hierna wordt deze in de root van de geclonede repofolder gezet. Bij het builden van de images met de specifieke Dockerfiles wordt de .dll mee gekopieerd naar de /app root van de images. 

Door gebruik te maken van conditionele hintpaths in de .csproj files van de projecten, wordt gecheckt of de .dll bestaat en ingeladen. 

