### PR TITLE
Fix potential DoS when using regex without a timeout

### DIFF
--- a/Mvc/Views/SchoolModule/Index.cshtml
+++ b/Mvc/Views/SchoolModule/Index.cshtml
@@ -24,11 +24,14 @@
                 </td>
                 <td>
                     @{
-                        var description = System.Text.RegularExpressions.Regex.Replace(item.Description, "<.*?>", string.Empty, System.Text.RegularExpressions.RegexOptions.NonBacktracking); // Remove HTML tags
-                        var words = description.Split(' ').Take(5);
-                        var shortDescription = string.Join(" ", words);
+                        if(item.Description != null)
+                        {
+                            var description = System.Text.RegularExpressions.Regex.Replace(item.Description, "<.*?>", string.Empty, System.Text.RegularExpressions.RegexOptions.NonBacktracking); // Remove HTML tags
+                            var words = description.Split(' ').Take(5);
+                            var shortDescription = string.Join(" ", words);
+                            @shortDescription
+                        }
                     }
-                    @shortDescription
                 </td>
                 <td>
                     @Html.ActionLink("Aanpassen", "Edit", new { id = item.Id }, new { @class = "btn btn-outline-secondary btn-sm" })

--- a/Mvc/Views/SchoolModule/Index.cshtml
+++ b/Mvc/Views/SchoolModule/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@using System.Web
+@using RegularExpressions = System.Text.RegularExpressions
 @model IEnumerable<SchoolModuleDto>
 
 @{
@@ -26,7 +27,10 @@
                     @{
                         if(item.Description != null)
                         {
-                            var description = System.Text.RegularExpressions.Regex.Replace(item.Description, "<.*?>", string.Empty, System.Text.RegularExpressions.RegexOptions.NonBacktracking); // Remove HTML tags
+                            var description = RegularExpressions.Regex.Replace(item.Description, 
+                                                                               "<.*?>", 
+                                                                               string.Empty, 
+                                                                               RegularExpressions.RegexOptions.NonBacktracking); 
                             var words = description.Split(' ').Take(5);
                             var shortDescription = string.Join(" ", words);
                             @shortDescription

--- a/Mvc/Views/SchoolModule/Index.cshtml
+++ b/Mvc/Views/SchoolModule/Index.cshtml
@@ -24,7 +24,7 @@
                 </td>
                 <td>
                     @{
-                        var description = System.Text.RegularExpressions.Regex.Replace(item.Description, "<.*?>", string.Empty); // Remove HTML tags
+                        var description = System.Text.RegularExpressions.Regex.Replace(item.Description, "<.*?>", string.Empty, System.Text.RegularExpressions.RegexOptions.NonBacktracking); // Remove HTML tags
                         var words = description.Split(' ').Take(5);
                         var shortDescription = string.Join(" ", words);
                     }


### PR DESCRIPTION
> Not specifying a timeout for regular expressions can lead to a Denial-of-Service attack. Pass a timeout when using System.Text.RegularExpressions to process untrusted input because a malicious user might craft a value for which the evaluation lasts excessively long.

Added a timeout so MVC isn't prone to such attacks when using a regex. 